### PR TITLE
Feature/nested config struct

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -4,9 +4,10 @@ import (
 	"encoding/hex"
 	"io"
 	"reflect"
-	"github.com/cryptogarageinc/server-common-go/pkg/utils/iso8601"
 	"strings"
 	"time"
+
+	"github.com/cryptogarageinc/server-common-go/pkg/utils/iso8601"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -381,13 +382,22 @@ func (c *Configuration) InitializeComponentConfig(compConf interface{}) error {
 }
 
 // Sub returns a new initialized SubConfiguration
+// return nil if the tag is not present
 func (c *Configuration) Sub(tag string) *Configuration {
+	subViper := c.viper.Sub(tag)
+	if subViper == nil {
+		return nil
+	}
+	subAppName := c.AppName + "." + tag
+	subViper.SetEnvPrefix(subAppName)
+	subViper.AutomaticEnv()
+	subViper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	return &Configuration{
-		AppName:         c.AppName,
+		AppName:         subAppName,
 		EnvironmentName: c.EnvironmentName,
 
 		paths:       c.paths,
-		viper:       c.viper.Sub(tag),
+		viper:       subViper,
 		initialized: true,
 	}
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -201,6 +201,21 @@ func TestConfigurationGetStringMap_WithStringMap_ReturnsCorrectValue(t *testing.
 	assert.Equal(expected, actual)
 }
 
+func TestConfigurationGetStruct_WithNestedStruct_ReturnsCorrectValue(t *testing.T) {
+	// Arrange
+	config := createConfiguration(t)
+	assert := assert.New(t)
+	expected := &NestedTestConfig{
+		Value: true,
+	}
+	// Act
+	actual, err := config.GetStruct("unittest.nested_struct", reflect.TypeOf(NestedTestConfig{}))
+
+	// Assert
+	assert.NoError(err)
+	assert.Equal(expected, actual)
+}
+
 func TestConfiguration_WithEnvironmentVariable_ReturnsEnvironmentVariableValue(t *testing.T) {
 	// Arrange
 	expected := 100
@@ -266,22 +281,23 @@ type NestedTestConfig struct {
 }
 
 type UnitTestConfig struct {
-	I         int                         `configkey:"unittest.i" validate:"min=10" default:"10"`
-	S         string                      `configkey:"unittest.s" validate:"required" default:"hoge"`
-	Ss        []string                    `configkey:"unittest.ss" validate:"dive,required" default:"hoge,fuga"`
-	B         bool                        `configkey:"unittest.b" default:"true"`
-	Utf8byte  []byte                      `configkey:"unittest.utf8byte,utf8" validate:"required" default:"abcde"`
-	Utf8NoEnc []byte                      `configkey:"unittest.utf8byte" validate:"required" default:"abcde"`
-	Hexbytes  []byte                      `configkey:"unittest.hexbyte,hex" validate:"required" default:"abcd0e"`
-	Dr        time.Duration               `configkey:"unittest.dr,duration" validate:"required" default:"1h10m10s"`
-	I64       int64                       `configkey:"unittest.i64" validate:"min=11" default:"132904"`
-	UI8       uint8                       `configkey:"unittest.ui8" validate:"min=8" default:"8"`
-	UI32      uint32                      `configkey:"unittest.ui32" validate:"min=32" default:"32"`
-	UI64      uint64                      `configkey:"unittest.ui64" validate:"min=64" default:"64"`
-	F32       float32                     `configkey:"unittest.f32" validate:"min=3.2" default:"3.2"`
-	F64       float64                     `configkey:"unittest.f64" validate:"min=6.4" default:"6.4"`
-	StringMap map[string]NestedTestConfig `configkey:"unittest.string_map"`
-	Ignored   bool
+	I            int                         `configkey:"unittest.i" validate:"min=10" default:"10"`
+	S            string                      `configkey:"unittest.s" validate:"required" default:"hoge"`
+	Ss           []string                    `configkey:"unittest.ss" validate:"dive,required" default:"hoge,fuga"`
+	B            bool                        `configkey:"unittest.b" default:"true"`
+	Utf8byte     []byte                      `configkey:"unittest.utf8byte,utf8" validate:"required" default:"abcde"`
+	Utf8NoEnc    []byte                      `configkey:"unittest.utf8byte" validate:"required" default:"abcde"`
+	Hexbytes     []byte                      `configkey:"unittest.hexbyte,hex" validate:"required" default:"abcd0e"`
+	Dr           time.Duration               `configkey:"unittest.dr,duration" validate:"required" default:"1h10m10s"`
+	I64          int64                       `configkey:"unittest.i64" validate:"min=11" default:"132904"`
+	UI8          uint8                       `configkey:"unittest.ui8" validate:"min=8" default:"8"`
+	UI32         uint32                      `configkey:"unittest.ui32" validate:"min=32" default:"32"`
+	UI64         uint64                      `configkey:"unittest.ui64" validate:"min=64" default:"64"`
+	F32          float32                     `configkey:"unittest.f32" validate:"min=3.2" default:"3.2"`
+	F64          float64                     `configkey:"unittest.f64" validate:"min=6.4" default:"6.4"`
+	StringMap    map[string]NestedTestConfig `configkey:"unittest.string_map"`
+	NestedStruct NestedTestConfig            `configkey:"unittest.nested_struct"`
+	Ignored      bool
 }
 
 type InvalidTestConfig struct {
@@ -329,6 +345,9 @@ func TestConfiguration_InitializeComponentConfig_CorrectlyInitializesConfig(t *t
 		"k1": {Value: true},
 		"k2": {Value: false},
 	}, unitTestConfig.StringMap)
+	assert.Equal(NestedTestConfig{
+		Value: true,
+	}, unitTestConfig.NestedStruct)
 
 }
 

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -4,11 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"github.com/cryptogarageinc/server-common-go/pkg/utils/iso8601"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/cryptogarageinc/server-common-go/pkg/utils/iso8601"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -209,6 +210,39 @@ func TestConfiguration_WithEnvironmentVariable_ReturnsEnvironmentVariableValue(t
 	assert := assert.New(t)
 	// Act
 	actual := config.GetInt("port")
+	// Assert
+	assert.Equal(expected, actual)
+}
+
+func TestConfiguration_Sub_ReturnsCorrectSubAndNilOnEmpty(t *testing.T) {
+	// Arrange
+	expected := 25
+
+	config := createConfiguration(t)
+	assert := assert.New(t)
+
+	// Act
+	subConfig := config.Sub("sub")
+	actual := subConfig.GetInt("port")
+
+	subConfigEmpty := config.Sub("keyNotPresent")
+
+	// Assert
+	assert.Equal(expected, actual)
+	assert.Nil(subConfigEmpty)
+}
+
+func TestSubConfiguration_WithEnvironmentVariable_ReturnsEnvironmentVariableValue(t *testing.T) {
+	// Arrange
+	expected := 100
+	os.Setenv("CORE_SUB_PORT", strconv.Itoa(expected))
+
+	config := createConfiguration(t)
+	assert := assert.New(t)
+
+	// Act
+	subConfig := config.Sub("sub")
+	actual := subConfig.GetInt("port")
 	// Assert
 	assert.Equal(expected, actual)
 }

--- a/test/config/unittest.yaml
+++ b/test/config/unittest.yaml
@@ -15,6 +15,8 @@ database:
   host: sqlite #mandatory fields but ignored when running with inmemory flag
   port: 5432
   dbpassword: 1234
+sub:
+  port: 25
 unittest:
   i: 10
   s: hoge

--- a/test/config/unittest.yaml
+++ b/test/config/unittest.yaml
@@ -40,4 +40,6 @@ unittest:
       value: true
     k2:
       value: false
+  nested_struct:
+    value: true
 


### PR DESCRIPTION
- fix environment variable prefix on `Sub` Configuration: problem was that the default `viper.Sub` doesn't update the environment variable settings
- add nested struct support

note: 
function `Sub` now returns a `nil` value to be consistent with the package `viper` `Sub`